### PR TITLE
Let the engine manage the path loading

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,6 @@ module TrustyCms
     include TrustyCms::Initializer
 
     config.autoload_paths += %W(#{TRUSTY_CMS_ROOT}/lib)
-    config.load_trusty_paths
 
     Sass.load_paths << Compass::Frameworks['compass'].stylesheets_directory
 


### PR DESCRIPTION
This goes with https://github.com/pgharts/trusty-cms/pull/88

I removed this method from trusty-cms since we shouldn't need to do it anymore, so don't call it here.
