### PR TITLE
Remove the sass-rails gem since it's now a proper dependency

### DIFF
--- a/Gemfile.example
+++ b/Gemfile.example
@@ -4,8 +4,6 @@ gem "trusty-cms", :path => '../trusty-cms'
 
 gem "mysql", "~> 2.9.1"
 
-gem "sass-rails", github: 'guilleiguaran/sass-rails', branch: 'backport'
-
 group :development do
   gem "pry-debugger"
   gem 'webrick', '~> 1.3.1'


### PR DESCRIPTION
Having trusty-cms in the gemfile now includes it :)
